### PR TITLE
MigrateDB Media Versioning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "advanced-custom-fields/advanced-custom-fields-pro": "^5.9",
     "deliciousbrains-plugin/wp-migrate-db-pro": "^2.0",
     "deliciousbrains-plugin/wp-migrate-db-pro-cli": "^1.3",
-    "deliciousbrains-plugin/wp-migrate-db-pro-media-files": "^2.0"
+    "deliciousbrains-plugin/wp-migrate-db-pro-media-files": "2.0.3"
   },
   "require-dev": {
     "wp-coding-standards/wpcs": "^2.3"


### PR DESCRIPTION
Delicious Brains license expired, and so we can't pull the most recent version of the plugins anymore.  Only updated the Media Files plugin for now while we decide how to move forward long-term. 