### PR TITLE
Removing Search from 'Amount' Options in Sidebar

### DIFF
--- a/wp-content/themes/oph/ui/css/custom.css
+++ b/wp-content/themes/oph/ui/css/custom.css
@@ -745,3 +745,7 @@ body.home header.is-scrolled .sitewide-search-button svg path {
 .select2-results .select2-results__options li.select2-results__option.active::after {
   opacity: 100; 
 } 
+
+.select2-dropdown .select2-search--hide + .select2-results .select2-results__options {
+  max-height: 200px; 
+}

--- a/wp-content/themes/oph/ui/js/main.js
+++ b/wp-content/themes/oph/ui/js/main.js
@@ -147,6 +147,7 @@ jQuery(function($) {
     var sidebarSelect = $('.sidebar-filter select').select2({
       dropdownCssClass: 'sidebar-filter-dropdown',
       searchInputPlaceholder: 'Type here to search ...',
+      minimumResultsForSearch: 5, 
       templateResult: select2CopyClasses,
       templateSelection: select2CopyClasses, 
       // allowClear: true 


### PR DESCRIPTION
Resetting `max-height` for any select2 dropdowns without a search, and set minimum results for search to 5. 